### PR TITLE
Switches from $timeout to $interval to support running Protractor tests

### DIFF
--- a/test/poller-model.js
+++ b/test/poller-model.js
@@ -2,15 +2,15 @@
 
 describe('Poller model:', function () {
 
-    var $resource, $timeout, $httpBackend, poller, resource1, resource2, poller1, poller2, result1, result2;
+    var $resource, $interval, $httpBackend, poller, resource1, resource2, poller1, poller2, result1, result2;
 
     beforeEach(function () {
 
         module('emguo.poller', 'ngResource');
 
-        inject(function (_$resource_, _$timeout_, _$httpBackend_, _poller_) {
+        inject(function (_$resource_, _$interval_, _$httpBackend_, _poller_) {
             $resource = _$resource_;
-            $timeout = _$timeout_;
+            $interval = _$interval_;
             $httpBackend = _$httpBackend_;
             poller = _poller_;
         });
@@ -81,26 +81,26 @@ describe('Poller model:', function () {
         expect(poller1).to.have.property('promise');
     });
 
-    it('should maintain a timeout ID to manage polling.', function () {
-        expect(poller1).to.have.property('timeout').to.have.property('$$timeoutId');
+    it('should maintain a interval ID to manage polling.', function () {
+        expect(poller1).to.have.property('interval').to.have.property('$$intervalId');
     });
 
-    it('should stop polling and reset timeout ID on invoking stop().', function () {
+    it('should stop polling and reset interval ID on invoking stop().', function () {
         poller1.stop();
-        expect(poller1.timeout.$$timeoutId).to.equal(null);
+        expect(poller1.interval).to.equal(null);
     });
 
     it('should restart currently running poller on invoking restart().', function () {
-        var timeoutId = poller1.timeout.$$timeoutId;
+        var intervalId = poller1.interval.$$intervalId;
         poller1.restart();
-        expect(poller1.timeout.$$timeoutId).to.not.equal(timeoutId);
+        expect(poller1.interval.$$intervalId).to.not.equal(intervalId);
     });
 
     it('should start already stopped poller on invoking restart().', function () {
         poller1.stop();
-        expect(poller1.timeout.$$timeoutId).to.equal(null);
+        expect(poller1.interval).to.equal(null);
         poller1.restart();
-        expect(poller1.timeout.$$timeoutId).to.not.equal(null);
+        expect(poller1.interval).to.not.equal(null);
     });
 
     it('should have correct data in callback.', function () {
@@ -121,7 +121,7 @@ describe('Poller model:', function () {
         $httpBackend.expect('GET', '/user?id=123').respond(
             {id: 123, name: 'Alice', number: '456'}
         );
-        $timeout.flush();
+        $interval.flush(6000);
         $httpBackend.flush();
 
         expect(result1.length).to.equal(3);

--- a/test/poller-registry-get.js
+++ b/test/poller-registry-get.js
@@ -35,7 +35,7 @@ describe('Poller registry:', function () {
             });
 
             it('should start poller.', function () {
-                expect(myPoller.timeout.$$timeoutId).not.to.equal(null);
+                expect(myPoller.interval.$$intervalId).not.to.equal(null);
             });
         });
 
@@ -93,15 +93,15 @@ describe('Poller registry:', function () {
 
             it('should start polling if it is currently stopped.', function () {
                 myPoller.stop();
-                expect(myPoller.timeout.$$timeoutId).to.equal(null);
+                expect(myPoller.interval).to.equal(null);
                 anotherPoller = poller.get(myResource);
-                expect(myPoller.timeout.$$timeoutId).to.not.equal(null);
+                expect(myPoller.interval.$$intervalId).to.not.equal(null);
             });
 
             it('should restart polling if it is currently running.', function () {
-                var timeoutId = myPoller.timeout.$$timeoutId;
+                var intervalId = myPoller.interval.$$intervalId;
                 anotherPoller = poller.get(myResource);
-                expect(anotherPoller.timeout.$$timeoutId).to.not.equal(timeoutId);
+                expect(anotherPoller.interval.$$intervalId).to.not.equal(intervalId);
             });
         });
     });

--- a/test/poller-registry.js
+++ b/test/poller-registry.js
@@ -27,24 +27,24 @@ describe('Poller registry:', function () {
 
     it('should stop all poller services on invoking stopAll().', function () {
         poller.stopAll();
-        expect(poller1.timeout.$$timeoutId).to.equal(null);
-        expect(poller2.timeout.$$timeoutId).to.equal(null);
+        expect(poller1.interval).to.equal(null);
+        expect(poller2.interval).to.equal(null);
     });
 
     it('should restart all poller services on invoking restartAll().', function () {
-        var timeoutId1 = poller1.timeout.$$timeoutId,
-            timeoutId2 = poller2.timeout.$$timeoutId;
+        var intervalId1 = poller1.interval.$$intervalId,
+            intervalId2 = poller2.interval.$$intervalId;
 
         poller.restartAll();
 
-        expect(poller1.timeout.$$timeoutId).to.not.equal(timeoutId1);
-        expect(poller2.timeout.$$timeoutId).to.not.equal(timeoutId2);
+        expect(poller1.interval.$$intervalId).to.not.equal(intervalId1);
+        expect(poller2.interval.$$intervalId).to.not.equal(intervalId2);
     });
 
     it('should stop and remove all poller services on invoking reset().', function () {
         poller.reset();
-        expect(poller1.timeout.$$timeoutId).to.equal(null);
-        expect(poller2.timeout.$$timeoutId).to.equal(null);
+        expect(poller1.interval).to.equal(null);
+        expect(poller2.interval).to.equal(null);
         expect(poller.size()).to.equal(0);
     });
 });


### PR DESCRIPTION
Protractor waits for all outstanding $timeouts and $http requests to complete before it considers the page to be loaded, so the poller would block protractor tests from running.

This change is based on the recommendation made in the Protractor FAQ (https://github.com/angular/protractor/blob/master/docs/faq.md#my-tests-time-out-in-protractor-but-everythings-working-fine-when-running-manually-whats-up) which is based on the resolution of this issue: https://github.com/angular/protractor/issues/49#issuecomment-26443073
