### PR TITLE
Using inline annotations for dependency injection

### DIFF
--- a/angular-poller.js
+++ b/angular-poller.js
@@ -44,7 +44,7 @@
             neverOverwrite: false
         })
 
-        .run(function ($rootScope, poller, pollerConfig) {
+        .run(['$rootScope', 'poller', 'pollerConfig', function ($rootScope, poller, pollerConfig) {
 
             /**
              * Automatically stop or reset all pollers before route change ($routeProvider) or state change ($stateProvider).
@@ -72,9 +72,9 @@
                     poller.reset();
                 });
             }
-        })
+        }])
 
-        .factory('poller', function ($interval, $q, $http, pollerConfig) {
+        .factory('poller', ['$interval', '$q', '$http', 'pollerConfig', function ($interval, $q, $http, pollerConfig) {
 
             var pollers = [], // Poller registry
 
@@ -310,6 +310,6 @@
                     pollers = [];
                 }
             };
-        }
+        }]
     );
 })(window, window.angular);


### PR DESCRIPTION
Switched to inline annotations for dependency injection to avoid breaking on minification.