### PR TITLE
Remove poller

### DIFF
--- a/angular-poller.js
+++ b/angular-poller.js
@@ -308,6 +308,19 @@
                 reset: function () {
                     this.stopAll();
                     pollers = [];
+                },
+
+                /**
+                * Stop and removes a specific poller service
+                */
+                remove: function (poller) {
+                    for (var i = 0, len = pollers.length; i < len; i++) {
+                        if (angular.equals(pollers[i], poller)) {
+                            pollers[i].stop();
+                            pollers.splice(i, 1);
+                            break;
+                        }
+                    }
                 }
             };
         }

--- a/test/angular-poller-spec.js
+++ b/test/angular-poller-spec.js
@@ -530,6 +530,16 @@ describe('emguo.poller', function () {
             expect(poller2.interval).to.equal(undefined);
             expect(poller.size()).to.equal(0);
         });
+
+        it('should stop and remove a specific poller service on invoking remove().', function () {
+            poller.remove(poller1);
+            expect(poller.size()).to.equal(1);
+        });
+
+        it('should handle not finding a specific poller service on invoking remove().', function () {
+            poller.remove({});
+            expect(poller.size()).to.equal(2);
+        });
     });
 });
 


### PR DESCRIPTION
Added functionality to remove a specific poller instance rather than having to rely upon reset() for issue #33 